### PR TITLE
CND-74 Update internal links to use react router

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-icons": "^4.9.0",
     "react-redux": "^8.0.5",
     "react-redux-firebase": "^3.11.0",
+    "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "5.0.1",
     "reactrangeslider": "^3.0.6",

--- a/src/components/RoutesIndex.tsx
+++ b/src/components/RoutesIndex.tsx
@@ -13,6 +13,7 @@ import {RouteStyle} from "../types/Grade";
 import {entries} from "../helpers/recordUtils";
 import {findUser, getUserName} from "../helpers/filterUtils";
 import {User} from "../types/User";
+import {LinkContainer} from 'react-router-bootstrap'
 
 
 export const SORT_FIELDS = [
@@ -126,8 +127,11 @@ const RoutesIndex = (props: RoutesFilterProps) => {
         <>
             <Row>
                 <Col xs={6}><h2>Routes</h2></Col>
-                <Col><Button href={`/routeGallery/filters${filterParams}`}
-                             style={{float: 'right'}}>Filters</Button></Col>
+                <Col>
+                    <LinkContainer to={`/routeGallery/filters${filterParams}`} style={{float: 'right'}}>
+                        <Button>Filters</Button>
+                    </LinkContainer>
+                </Col>
             </Row>
             <Row>
                 {cards.map((card, idx) => <Col key={idx} xs={6} sm={4} md={3} lg={2}>{card}</Col>)}
@@ -191,7 +195,7 @@ const calculateProjectTimes = (routeKey: string, sessionsByUser: Record<string, 
                 isSent = true
             }
 
-            return { uid, sessionCount, isSent }
+            return {uid, sessionCount, isSent}
         })
 }
 

--- a/src/components/StatsIndex.tsx
+++ b/src/components/StatsIndex.tsx
@@ -12,12 +12,15 @@ import {RouteCount, Session} from "../types/Session";
 import {Data} from "../types/Firebase";
 import {Grade, RouteStyle} from "../types/Grade";
 import {Gym} from "../types/Gym";
+import {LinkContainer} from 'react-router-bootstrap'
 
 export const StatItem = ({label, value, link}: { label: string, value?: string | number, link?: string }) => {
-    const itemProps = link ? {action: true, href: link} : {};
-
-    return (
-        <ListGroupItem {...itemProps} style={{paddingTop: '8px', paddingBottom: '8px'}}>
+    const paddingStyle = {paddingTop: '8px', paddingBottom: '8px'}
+    // Some stat items are links - those will get the `action` prop
+    // The outermost element should have the padding style applied - for links, that will be the LinkContainer, but for non-links, that will be the ListGroupItem
+    const listItemProps = link ? {action: true} : {style: paddingStyle}
+    const listItem = (
+        <ListGroupItem {...listItemProps}>
             <Row style={{marginBottom: '0'}}>
                 <Col xs={6}>
                     {label}
@@ -29,6 +32,13 @@ export const StatItem = ({label, value, link}: { label: string, value?: string |
             </Row>
         </ListGroupItem>
     )
+
+    if (link) {
+        return <LinkContainer to={link} style={paddingStyle}>
+            {listItem}
+        </LinkContainer>
+    }
+    return listItem
 };
 
 export const partialRouteCount = <T, >(route: RouteCount<T>): number => route.partials && Object.entries(route.partials).map(([key, val]) => Number(key) * val / PARTIAL_MAX).reduce(sum, 0) || 0;
@@ -116,7 +126,7 @@ const StatsIndex = ({gyms, routes, sessions, allowSuffixes, allowedTypes, allowP
         <>
             <Row>
                 <Col xs={6}><h2>Stats</h2></Col>
-                <Col><Button href={filtersLink(location)} style={{float: 'right'}}>Filters</Button></Col>
+                <Col><LinkContainer to={filtersLink(location)} style={{float: 'right'}}><Button>Filters</Button></LinkContainer></Col>
             </Row>
             <Row>
                 <Col><h4>Totals</h4></Col>

--- a/src/containers/RouteFilters.tsx
+++ b/src/containers/RouteFilters.tsx
@@ -10,6 +10,7 @@ import {MultiSelect} from "./StatFilters";
 import {firebaseState, getUser} from "../redux/selectors";
 import {entries} from "../helpers/recordUtils";
 import {sortOptions} from "../components/RoutesIndex";
+import {LinkContainer} from 'react-router-bootstrap'
 
 
 const defaultIfEmpty = (a1, a2) => {
@@ -114,7 +115,7 @@ const RouteFilters = () => {
             <Form.Check type='radio' label='Descending' checked={sortDesc}
                         onChange={() => setSortDesc(true)}/>
 
-            <Button href={`${returnUrl}?${generateQueryParams()}`}>Confirm</Button>
+            <LinkContainer to={`${returnUrl}?${generateQueryParams()}`}><Button>Confirm</Button></LinkContainer>
         </>
     );
 };

--- a/src/containers/Sidebar.tsx
+++ b/src/containers/Sidebar.tsx
@@ -1,6 +1,7 @@
 import {ListGroup, Offcanvas} from "react-bootstrap";
 import React from "react";
 import {useAppSelector} from "../redux/index"
+import {LinkContainer} from 'react-router-bootstrap'
 
 export const Sidebar = ({show, onHide}) => {
     const auth = useAppSelector(state => state.auth)
@@ -13,7 +14,9 @@ export const Sidebar = ({show, onHide}) => {
                 <ListGroup variant="flush">
                     {
                         listItems.map(({href, text}, idx) => (
-                            <ListGroup.Item action href={href} key={idx}>{text}</ListGroup.Item>)
+                            <LinkContainer to={href} key={idx} isActive={() => false}>
+                                <ListGroup.Item action onClick={onHide}>{text}</ListGroup.Item>
+                            </LinkContainer>)
                         )
                     }
                 </ListGroup>

--- a/src/containers/StatFilters.tsx
+++ b/src/containers/StatFilters.tsx
@@ -6,6 +6,7 @@ import {ALL_STYLES, printType} from '../helpers/gradeUtils';
 import {findUser, getFriendsForUser, getGymsForUser, getUserName} from '../helpers/filterUtils';
 import {getBooleanFromQuery} from './StatsContainer';
 import {firebaseState, getUser} from "../redux/selectors";
+import {LinkContainer} from 'react-router-bootstrap'
 
 export const filtersLink = (location) => `/stats/filters${location.search ? location.search + '&' : '?'}ref=${location.pathname}`;
 
@@ -128,7 +129,7 @@ const StatFilters = () => {
             <Form.Check type='radio' id='pn' key='pn' label='Ignore Partials' checked={!allowPartials}
                         onChange={() => setAllowPartials(false)}/>
 
-            <Button href={`${returnUrl}?${generateQueryParams()}`}>Confirm</Button>
+            <LinkContainer to={`${returnUrl}?${generateQueryParams()}`}><Button>Confirm</Button></LinkContainer>
         </>
     );
 };

--- a/src/containers/StatsContainer.tsx
+++ b/src/containers/StatsContainer.tsx
@@ -12,6 +12,7 @@ import {Button} from 'react-bootstrap';
 import {filterList, findFriends, getGymsForUser} from "../helpers/filterUtils";
 import {firebaseState, getUser} from "../redux/selectors";
 import {isStyle, RouteStyle} from "../types/Grade";
+import {LinkContainer} from 'react-router-bootstrap'
 
 const filterByKeys = (data, keys) => {
     if (!data) return [];
@@ -21,8 +22,8 @@ const filterByKeys = (data, keys) => {
 
 const StatsHeader = ({location}) => (
     <>
-    <Button variant='link' href={`/stats${location.search}`}><FaChevronLeft />Stats</Button>
-    <Button href={filtersLink(location)} style={{float: 'right'}}>Filters</Button>
+        <LinkContainer to={`/stats${location.search}`}><Button variant='link'><FaChevronLeft />Stats</Button></LinkContainer>
+        <LinkContainer to={filtersLink(location)} style={{float: 'right'}}><Button>Filters</Button></LinkContainer>
     </>
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8061,7 +8061,7 @@ prop-types-extra@^1.1.0:
     react-is "^16.3.2"
     warning "^3.0.0"
 
-prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8325,6 +8325,13 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-router-bootstrap@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/react-router-bootstrap/-/react-router-bootstrap-0.25.0.tgz#5d1a99b5b8a2016c011fc46019d2397e563ce0df"
+  integrity sha512-/22eqxjn6Zv5fvY2rZHn57SKmjmJfK7xzJ6/G1OgxAjLtKVfWgV5sn41W2yiqzbtV5eE4/i4LeDLBGYTqx7jbA==
+  dependencies:
+    prop-types "^15.5.10"
 
 react-router-dom@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
Fixes #74
This uses the `react-router-bootstrap` library to convert bootstrap links into links that will defer to react-router instead of trying server-side routing. This will prevent full page reloads when using those links, which leads to a less clunky experience in general (with a nice performance benefit of not needing to load data from firebase again).