### PR TITLE
Bugfix: ActivityFeed infinite render fix + empty state

### DIFF
--- a/src/components/activity-feed/EmptyFeed.tsx
+++ b/src/components/activity-feed/EmptyFeed.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Card, Col, Container, Row } from 'react-bootstrap'
+import { Link } from 'react-router-dom'
+
+export const EmptyFeed = () => {
+  return (
+    <Container id={'activity-feed-empty'}>
+      <Row>
+        <Col xs={12}>
+          <Card className="empty">
+            <h3 className="lead text-center">Activity Feed</h3>
+            <p>
+              Sorry, there are no records available. To populate your activity feed, you have the
+              option to:
+            </p>
+            <ul>
+              <li>
+                Visit your <Link to="/gyms">Gyms</Link> to create a home for your climbing sessions
+              </li>
+              <li>
+                Visit your <Link to="/workouts">Workouts</Link> to log a workout.
+              </li>
+              <li>
+                Visit your <Link to="/user">User Settings</Link> to add friends and view their
+                activity!
+              </li>
+            </ul>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  )
+}

--- a/src/containers/ActivityFeed.tsx
+++ b/src/containers/ActivityFeed.tsx
@@ -6,6 +6,7 @@ import { useHistory, useLocation } from 'react-router-dom'
 import { getNumberFromQuery, getQuery } from '../helpers/queryParser'
 import { buildFeedData, FeedItem } from '../helpers/activityFeedBuilder'
 import FeedItemCard from '../components/activity-feed/FeedItemCard'
+import { EmptyFeed } from '../components/activity-feed/EmptyFeed'
 
 const PAGE_SIZE = 20
 const DEFAULT_ITEMS = PAGE_SIZE * 3
@@ -26,7 +27,7 @@ const ActivityFeed = () => {
     getNumberFromQuery(getQuery(location), 'n', DEFAULT_ITEMS),
   )
 
-  const [feedData, setFeedData] = useState<FeedItem[]>([])
+  const [feedData, setFeedData] = useState<FeedItem[] | null>(null)
 
   useEffect(() => {
     history.replace({ pathname: location.pathname, search: `?n=${feedLength}` })
@@ -40,7 +41,7 @@ const ActivityFeed = () => {
       isLoaded(users) &&
       isLoaded(routes) &&
       isLoaded(workouts) &&
-      feedData.length === 0
+      feedData === null
     ) {
       setFeedData(buildFeedData(uid, gyms, sessions, users, routes, workouts))
     }
@@ -57,25 +58,29 @@ const ActivityFeed = () => {
 
   return (
     <div className="activity-feed">
-      <InfiniteScroll
-        next={() => setFeedLength(len => len + PAGE_SIZE)}
-        hasMore={feedLength < feedData.length}
-        dataLength={feedLength}
-        loader={<></>}
-      >
-        {feedData.slice(0, feedLength).map((feedItem, idx) => (
-          <FeedItemCard
-            key={idx}
-            feedItem={feedItem}
-            uid={uid}
-            gyms={gyms}
-            sessions={sessions}
-            users={users}
-            routes={routes}
-            workouts={workouts}
-          />
-        ))}
-      </InfiniteScroll>
+      {feedData && feedData.length ? (
+        <InfiniteScroll
+          next={() => setFeedLength(len => len + PAGE_SIZE)}
+          hasMore={feedLength < feedData.length}
+          dataLength={feedLength}
+          loader={<></>}
+        >
+          {feedData.slice(0, feedLength).map((feedItem, idx) => (
+            <FeedItemCard
+              key={idx}
+              feedItem={feedItem}
+              uid={uid}
+              gyms={gyms}
+              sessions={sessions}
+              users={users}
+              routes={routes}
+              workouts={workouts}
+            />
+          ))}
+        </InfiniteScroll>
+      ) : (
+        <EmptyFeed />
+      )}
     </div>
   )
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -171,4 +171,9 @@
     img {
         max-height: 20em;
     }
+
+    .empty {
+        background-color: $gray-100;
+        padding: 1em;
+    }
 }


### PR DESCRIPTION
## Summary
* Fix `ActivityFeed` state logic to begin from a null state. This helps stabilize the logic by being able to differentiate initial state from later possible empty state.
* Add `EmptyFeed` component to present user with various CTAs to populate their activity field to encourage them to reach a non-empty state.

## Commit Log 
* fix: prevent infinite render loop on empty feedData, add empty state