### PR TITLE
Bugfix: empty Stats page fixes

### DIFF
--- a/src/components/StatsIndex.tsx
+++ b/src/components/StatsIndex.tsx
@@ -30,10 +30,10 @@ export const StatItem = ({
   const listItem = (
     <ListGroupItem {...listItemProps}>
       <Row style={{ marginBottom: '0' }}>
-        <Col xs={6}>{label}</Col>
-        {value && <Col>{value}</Col>}
+        <Col xs={7}>{label}</Col>
+        <Col xs={link ? 3 : 4}>{value}</Col>
         {link && (
-          <Col xs={2}>
+          <Col xs={2} className="d-flex align-items-center justify-content-end">
             <FaChevronRight />
           </Col>
         )}
@@ -222,7 +222,7 @@ const StatsIndex = ({
           value={totalRoutes}
           link={`/stats/gradeHistogram${filterParams}`}
         />
-        <StatItem label={'Total distance'} value={`${totalDistance} ft`} />
+        <StatItem label={'Total distance'} value={`${totalDistance}ft`} />
         <StatItem
           label={`Hardest grade${allowedTypes.length > 1 ? 's' : ''}`}
           value={Object.values(maxGrades)
@@ -239,10 +239,10 @@ const StatsIndex = ({
       </Row>
       <ListGroup>
         <StatItem label={'Time spent'} value={durationString(totalTime / numSessions)} />
-        <StatItem label={'Routes climbed'} value={Math.round(totalRoutes / numSessions)} />
+        <StatItem label={'Routes climbed'} value={Math.round(totalRoutes / numSessions) || 0} />
         <StatItem
           label={'Distance climbed'}
-          value={`${Math.round(totalDistance / numSessions)} ft`}
+          value={`${Math.round(totalDistance / numSessions) || 0}ft`}
         />
       </ListGroup>
     </>

--- a/src/components/StatsIndex.tsx
+++ b/src/components/StatsIndex.tsx
@@ -5,7 +5,7 @@ import { FaChevronRight } from 'react-icons/fa'
 import { useLocation } from 'react-router-dom'
 import { durationString } from '../helpers/durationUtils'
 import { filtersLink } from '../containers/StatFilters'
-import { max, pluralize, sum } from '../helpers/mathUtils'
+import { max, pluralize, round, sum } from '../helpers/mathUtils'
 import { PARTIAL_MAX } from './GradeModal'
 import { Route } from '../types/Route'
 import { RouteCount, Session } from '../types/Session'
@@ -239,11 +239,8 @@ const StatsIndex = ({
       </Row>
       <ListGroup>
         <StatItem label={'Time spent'} value={durationString(totalTime / numSessions)} />
-        <StatItem label={'Routes climbed'} value={Math.round(totalRoutes / numSessions) || 0} />
-        <StatItem
-          label={'Distance climbed'}
-          value={`${Math.round(totalDistance / numSessions) || 0}ft`}
-        />
+        <StatItem label={'Routes climbed'} value={round(totalRoutes / numSessions)} />
+        <StatItem label={'Distance climbed'} value={`${round(totalDistance / numSessions)}ft`} />
       </ListGroup>
     </>
   )

--- a/src/containers/StatFilters.tsx
+++ b/src/containers/StatFilters.tsx
@@ -50,7 +50,7 @@ const StatFilters = () => {
 
   const query = new URLSearchParams(useLocation().search)
 
-  const [gymIds, setGymIds] = useState<string[]>(defaultIfEmpty(query.getAll('gyms'), []))
+  const [gymIds, setGymIds] = useState<string[] | null>(defaultIfEmpty(query.getAll('gyms'), null))
   const [uids, setUids] = useState<string[]>(defaultIfEmpty(query.getAll('uids'), []))
 
   const [allowSuffixes, setAllowSuffixes] = useState(getBooleanFromQuery(query, 'allowSuffixes'))
@@ -63,7 +63,7 @@ const StatFilters = () => {
   )
 
   useEffect(() => {
-    if (isLoaded(gyms) && gymIds.length === 0) {
+    if (isLoaded(gyms) && gymIds === null) {
       setGymIds(gyms.map(gym => gym.key))
     }
   }, [gyms])
@@ -91,7 +91,7 @@ const StatFilters = () => {
   const gymOptions = gyms.map(({ key, value }) => ({
     key,
     label: value.name,
-    checked: gymIds.includes(key),
+    checked: gymIds && gymIds.includes(key),
   }))
 
   const styleOptions = ALL_STYLES.map(style => ({
@@ -102,7 +102,7 @@ const StatFilters = () => {
 
   const generateQueryParams = () => {
     const queryParams = new URLSearchParams()
-    gymIds.forEach(id => queryParams.append('gyms', id))
+    gymIds && gymIds.forEach(id => queryParams.append('gyms', id))
     uids.forEach(id => queryParams.append('uids', id))
     allowedTypes.forEach(type => queryParams.append('allowedTypes', type))
     queryParams.append('allowSuffixes', `${allowSuffixes}`)

--- a/src/helpers/durationUtils.tsx
+++ b/src/helpers/durationUtils.tsx
@@ -2,11 +2,11 @@ import { Session } from '../types/Session'
 
 export const durationString = (durationMillis: number, includeMinutes = true) => {
   const hours = Math.floor(durationMillis / 3600000)
-  const hoursString = `${hours}h`
+  const hoursString = `${hours || 0}h`
 
   if (includeMinutes) {
     const minutes = Math.floor((durationMillis % 3600000) / 60000)
-    const minutesString = `${minutes}m`
+    const minutesString = `${minutes || 0}m`
     return hoursString + ' ' + minutesString
   } else {
     return hoursString

--- a/src/helpers/mathUtils.tsx
+++ b/src/helpers/mathUtils.tsx
@@ -24,3 +24,5 @@ export const sumByKey = (o1: Record<string, number>, o2: Record<string, number>)
   )
 
 export const pluralize = (str, count, plural = `${str}s`) => (count == 1 ? str : plural)
+
+export const round = (num: number) => Math.round(num) || 0


### PR DESCRIPTION
## Summary
* Clean up `StatsIndex` when in a new-account state (no gyms, etc) to prevent `NaN` text from appearing
* Prevent infinite loop in `StatFilters` due to 0 gyms registered

## Preview
* Before https://i.imgur.com/VyuAPG3.png
* After https://i.imgur.com/Tcp8QCy.png

## Commit Log
* chore: replace NaN cases with 0, clean up unit and chevron behavior
* fix: prevent empty gyms from causing infinite loop in stat filters page